### PR TITLE
[feat]: 로그인 반환 결과에 role 추가

### DIFF
--- a/src/main/java/com/bingbong/consult/member/application/MemberService.java
+++ b/src/main/java/com/bingbong/consult/member/application/MemberService.java
@@ -48,7 +48,6 @@ public class MemberService {
         if(member.isPresent()) {
             Member m = member.get();
             return MemberDto.builder()
-                    .id(m.getId())
                     .name(m.getName())
                     .email(m.getEmail())
                     .childName(m.getChildName())

--- a/src/main/java/com/bingbong/consult/member/presentation/MemberController.java
+++ b/src/main/java/com/bingbong/consult/member/presentation/MemberController.java
@@ -4,6 +4,7 @@ import com.bingbong.consult.member.application.MemberService;
 import com.bingbong.consult.member.presentation.dto.MemberDto;
 import com.bingbong.consult.member.presentation.dto.MemberKeyDto;
 import com.bingbong.consult.security.TokenDto;
+import com.bingbong.consult.security.TokenProvider;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 @SecurityRequirement(name = "Bearer Authentication")
 public class MemberController {
     private final MemberService memberService;
+    private final TokenProvider tokenProvider;
     @PostMapping("/members/login")
     public ResponseEntity<TokenDto> registerMember(@RequestBody MemberDto form) {
         String jwt = memberService.register(form);
@@ -38,7 +40,7 @@ public class MemberController {
     private HttpHeaders responseHeader(String jwt) {
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.add("Bearer", "" + jwt);
-//        httpHeaders.add("Level", tokenProvider.getAuthentication(jwt).authorities.joinToString { it.authority });
+        httpHeaders.add("Role", tokenProvider.getAuthentication(jwt).getAuthorities().toString());
         return httpHeaders;
     }
 }

--- a/src/main/java/com/bingbong/consult/member/presentation/dto/MemberDto.java
+++ b/src/main/java/com/bingbong/consult/member/presentation/dto/MemberDto.java
@@ -6,10 +6,8 @@ import lombok.Data;
 @Data
 @Builder
 public class MemberDto {
-    Long id;
     String name;
     String email;
     String childName;
-    String kakaoKey;
     String role; // PARENT, TEACHER
 }


### PR DESCRIPTION
프론트에서는 role을 가지고 접근가능한 페이지, 아닌 페이지를 구분할 수 있다.
혹은 선생님으로 로그인했을 시 보여줄 첫 페이지, 학부모로 로그인 했을 시 보여줄 첫 페이지를 다르게 설정해줄 수 있다. 